### PR TITLE
fix: add impression telemetry on home, watch, and search pages

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,6 +23,7 @@ import { chunk } from "lodash";
 import { useNavigate } from "react-router-dom";
 import { fetchSearchResults } from "../services/content";
 import ContentCard from "../components/common/cards/ContentCard";
+import { impression } from "../services/telemetry";
 
 const subjectIcons = {
   science: { icon: physics, label: "Science" },
@@ -123,6 +124,17 @@ export default function Homepage(props: any) {
       if (storedSubject) {
         handleSelectSubject(storedSubject);
       }
+      impression({
+        edata: {
+          type: "Home",
+          pageid: "HOME",
+          uri: "/home",
+          query: Object.fromEntries(
+            new URLSearchParams(location.search).entries()
+          ),
+          visits: [],
+        },
+      });
     };
     init();
   }, []);

--- a/src/pages/videos/SearchPage.tsx
+++ b/src/pages/videos/SearchPage.tsx
@@ -1,18 +1,11 @@
+import { Box, Grid, GridItem, Text, VStack } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import {
-  Badge,
-  Box,
-  Image,
-  Text,
-  VStack,
-  Grid,
-  GridItem,
-} from "@chakra-ui/react";
+import { useLocation, useNavigate } from "react-router-dom";
+import ContentCard from "../../components/common/cards/ContentCard";
+import Layout from "../../components/common/layout/layout";
 import Loading from "../../components/common/Loading";
 import { fetchSearchResults } from "../../services/content";
-import Layout from "../../components/common/layout/layout";
-import ContentCard from "../../components/common/cards/ContentCard";
+import { impression } from "../../services/telemetry";
 
 const SearchPage: React.FC = () => {
   const navigate = useNavigate();
@@ -26,7 +19,19 @@ const SearchPage: React.FC = () => {
     const params = new URLSearchParams(location.search);
     return params.get(key) || "";
   };
-
+  useEffect(() => {
+    impression({
+      edata: {
+        type: "Search",
+        pageid: "SEARCH",
+        uri: "/search",
+        query: Object.fromEntries(
+          new URLSearchParams(location.search).entries()
+        ),
+        visits: [],
+      },
+    });
+  }, []);
   useEffect(() => {
     const query = getParameter("search");
     setSearchTerm(query);

--- a/src/pages/videos/WatchScreen.tsx
+++ b/src/pages/videos/WatchScreen.tsx
@@ -17,6 +17,7 @@ import defaultImage from "../../assets/images/default-img.png";
 import { useTranslation } from "react-i18next";
 import { getSubjectList } from "../../services/home";
 import ContentCard from "../../components/common/cards/ContentCard";
+import { impression } from "../../services/telemetry";
 
 type Filter = {
   searchTerm: string;
@@ -89,6 +90,17 @@ const Watch = () => {
 
   useEffect(() => {
     const getSubject = async () => {
+      impression({
+        edata: {
+          type: "Watch",
+          pageid: "WATCH",
+          uri: "/watch",
+          query: Object.fromEntries(
+            new URLSearchParams(location.search).entries()
+          ),
+          visits: [],
+        },
+      });
       try {
         let storedSubject = localStorage.getItem("language") || "";
         const res: any = await getSubjectList();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -104,6 +104,13 @@ export const search = async (props: Record<string, any> = {}) => {
   return await commonFetchCall(dataString);
 };
 
+export const impression = async (props: Record<string, any> = {}) => {
+  const dataString = JSON.stringify(
+    getDefaultStartEvent({ eid: "IMPRESSION", ...props })
+  );
+  return await commonFetchCall(dataString);
+};
+
 export const commonFetchCall = async (dataString: string) => {
   return await fetch(`${VITE_TELEMETRY_BASE_URL}${VITE_TELEMETRY_END_POINT}`, {
     method: "POST",


### PR DESCRIPTION
* Added impression telemetry to track user activity on the home, watch, and search pages.
* Ensured the telemetry captures relevant metadata for better reporting and analytics.
* Tested the implementation to verify proper event logging.